### PR TITLE
fix: align types across multiple jest versions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { Transformer, TransformOptions } from './types';
 const getCacheKey = (
   fileData: string,
   filePath: string,
-  options: TransformOptions<unknown>,
+  options: TransformOptions<unknown> | string,
 ): string => {
   const optionsString = typeof options === 'string' ? options : JSON.stringify(options);
 


### PR DESCRIPTION
This provides explicit typing around potential different options types