### PR TITLE
Update engine filed to include v18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [12.x, 14.x, 16.x, 17.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": "^12.0.0 || ^14.0.0 || ^16.0.0 || ^17.0.0"
+    "node": "^12.0.0 || ^14.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "keywords": [
     "jest",


### PR DESCRIPTION
While update onto node v18, I saw this error popping up and given that 18 will become the next LTS version it might be a good idea to include it already. https://nodejs.org/en/about/releases/


> error jest-transform-yaml@1.0.0: The engine "node" is incompatible with this module. Expected version "^12.0.0 || ^14.0.0 || ^16.0.0 || ^17.0.0". Got "18.0.0"