### PR TITLE
Update `engines` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": "^12.0.0 || ^14.0.0 || ^16.0.0 || ^17.0.0"
+    "node": "^12.0.0 || ^14.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "keywords": [
     "jest",


### PR DESCRIPTION
We're using this package in a Node 18 app with no issues. This change gets rid of the engines mismatch warning when you `npm install`.